### PR TITLE
Fix GitHub broken link

### DIFF
--- a/src/components/HeadingWrap/index.js
+++ b/src/components/HeadingWrap/index.js
@@ -43,7 +43,7 @@ function HeadingWrap() {
                             title='Github Repository'
                             target='_blank'
                             rel='noreferrer'
-                            href='https://github.com/juliajcodes'
+                            href='https://github.com/juliacodes'
                         >
                             <Social>
                                 <svg


### PR DESCRIPTION
I was checking out your portfolio and turns out that link was returning a `404` 😅 
Fixed!